### PR TITLE
Move isolation et. al.

### DIFF
--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1391,53 +1391,6 @@
 
         </dl>
       </section>
-
-      <section>
-        <h2>Isolated Media Streams</h2>
-
-
-        <p>When the <code><dfn>peerIdentity</dfn></code> option is supplied to
-        <code><a>getUserMedia</a></code>, the resulting
-        <code><a>MediaStream</a></code> is isolated so that its content is not
-        accessible to any application. An isolated
-        <code><a>MediaStream</a></code> may be used for two purposes:</p>
-
-        <ul>
-          <li>
-            <p>Displayed in an appropriate tag (e.g., a video or audio
-            element). The browser MUST ensure that content is inaccessible to
-            the application by ensuring that the resulting content is given the
-            same protections as content that is <a
-            href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#cors-cross-origin">CORS
-            cross-origin</a>, as described in the relevant <a
-            href="www.w3.org/html/wg/drafts/html/master/embedded-content-0.html#security-and-privacy-considerations">Security
-            and privacy considerations section </a> of [[HTML5]].</p>
-          </li>
-
-
-          <li>
-            <p>Used as the argument to addStream() for an RTCPeerConnection,
-            subject to the restrictions detailed in [[WEBRTC10]].</p>
-          </li>
-        </ul>
-
-        <p>A <code><a>MediaStreamTrack</a></code> that is added to another
-        <code><a>MediaStream</a></code> remains isolated.  Tracks that are
-        isolated can be added to other <code><a>MediaStream</a></code>s, but
-        this causes the resulting MediaStream to have a combination of isolation
-        restrictions.  A <code><a>MediaStream</a></code> containing
-        <code><a>MediaStreamTrack</a></code> instances with mixed isolation
-        properties can be displayed, but cannot be sent using
-        RTCPeerConnection.</p>
-
-        <p>Any peerIdentity property MUST be retained
-        on <a href="#widl-MediaStreamTrack-clone-MediaStreamTrack">clone</a>d
-        copies of <code><a>MediaStreamTrack</a></code>s.<!-- Any stream or track
-        that might be derived from an isolated stream, such as
-        through <a href="https://www.w3.org/TR/streamproc/#media-element-extensions">captureStreamUntilEnded
-        or captureStream</a>, MUST also retain any isolation protections.</p>
-        -->
-      </section>
     </section>
 
 
@@ -1460,7 +1413,6 @@
       <code><a href="#dom-mediastreamtrackevent-track">track</a></code>
       attribute set to <var>track</var>, MUST be created and dispatched at the
       given target.</p>
-
 
       <dl class="idl" data-merge="MediaStreamTrackEventInit" title=
       "interface MediaStreamTrackEvent : Event">
@@ -3067,14 +3019,6 @@
           of the audio Track. If <code>false</code>, the <a>MediaStream</a>
           MUST not contain an audio Track.</p>
         </dd>
-
-        <dt>DOMString peerIdentity</dt>
-
-        <dd>
-          <p>If the <code>peerIdentity</code> attribute is provided, the
-          resulting <a>MediaStream</a> will be <a
-          href="#isolated-media-streams">isolated from the application</a>.</p>
-        </dd>
       </dl>
 
 
@@ -4350,6 +4294,8 @@ for the properties of O.</li>
       <li>Clarified that skipping of optional/advanced ConstraintSets
       is only permitted if they cannot be satisfied, not merely
       because the user agent wishes to.</li>
+
+      <li>Moved peerIdentity related text to WebRTC.</li>
     </ol>
 
 

--- a/getusermedia.html
+++ b/getusermedia.html
@@ -1245,13 +1245,13 @@
             "#dom-mediastreamtrack-stop">stop()</a></code> method is the DOM
             manipulation task source.</p>
           </dd>
-          
+
                   <dt>Capabilities getCapabilities()</dt>
 
 
         <dd>
           <p>See <a href="#constraintable-interface">Constrainable Interface</a>
-          	for the definition of this method.</p>
+                for the definition of this method.</p>
         </dd>
 
 
@@ -1259,7 +1259,7 @@
 
 
         <dd>See <a href="#constraintable-interface">Constrainable Interface</a>
-          	for the definition of this method.
+                for the definition of this method.
         </dd>
 
 
@@ -1267,7 +1267,7 @@
 
 
         <dd>See <a href="#constraintable-interface">Constrainable Interface</a>
-          	for the definition of this method.
+                for the definition of this method.
 </dd>
         <dt>void applyConstraints()</dt>
         <dd>
@@ -1290,7 +1290,7 @@
             <dd>Called if the required constraints cannot be satisfied.</dd>
           </dl>
  See <a href="#constraintable-interface">Constrainable Interface</a>
-          	for the definition of this method.</dd>
+                for the definition of this method.</dd>
         <dd>
         </dl>
 
@@ -1365,31 +1365,32 @@
           audio-producing microphone source.</dd>
         </dl>
       </section>
-<section id="media-track-constraints">
-	<h2>MediaTrackConstraints</h2>
-	   <dl class="idl" title="dictionary MediaTrackConstraints : MediaTrackConstraintSet"> 
-    <dt>sequence&lt;MediaTrackConstraintSet&gt; advanced</dt>
-    <dd>See <a href="#constraints">Constraints and ConstraintSet</a> for
-    the definition of this element.</dd>
-    <dt>sequence&lt;DOMString&gt; require</dt>
-       <dd>See <a href="#constraints">Constraints and ConstraintSet</a> for
-    the definition of this element.</dd>
- </dl>
-        
-    <dl class="idl" title="dictionary MediaTrackConstraintSet">      
-  <dt>ConstrainLong width</dt> <dd> </dd>
-  <dt>ConstrainLong height</dt> <dd> </dd>
-    <dt>ConstrainDouble aspectRatio</dt><dd> </dd>
-    <dt>ConstrainDouble frameRate</dt> <dd> </dd>
-    <dt>ConstrainVideoFacingMode facingMode</dt> <dd> </dd>
-    <dt>ConstrainDouble volume</dt> <dd> </dd>
-    <dt>ConstrainLong sampleRate</dt> <dd> </dd>
-    <dt>ConstrainLong sampleSize</dt><dd> </dd>
-    <dt>boolean echoCancelation</dt><dd> </dd>
-    <dt>ConstrainDOMString sourceId</dt> <dd> </dd>
-    
-  </dl>
-	</section>
+
+      <section id="media-track-constraints">
+        <h2>MediaTrackConstraints</h2>
+        <dl class="idl" title="dictionary MediaTrackConstraints : MediaTrackConstraintSet">
+          <dt>sequence&lt;MediaTrackConstraintSet&gt; advanced</dt>
+          <dd>See <a href="#constraints">Constraints and ConstraintSet</a> for
+            the definition of this element.</dd>
+          <dt>sequence&lt;DOMString&gt; require</dt>
+          <dd>See <a href="#constraints">Constraints and ConstraintSet</a> for
+            the definition of this element.</dd>
+        </dl>
+
+        <dl class="idl" title="dictionary MediaTrackConstraintSet">
+          <dt>ConstrainLong width</dt> <dd> </dd>
+          <dt>ConstrainLong height</dt> <dd> </dd>
+          <dt>ConstrainDouble aspectRatio</dt><dd> </dd>
+          <dt>ConstrainDouble frameRate</dt> <dd> </dd>
+          <dt>ConstrainVideoFacingMode facingMode</dt> <dd> </dd>
+          <dt>ConstrainDouble volume</dt> <dd> </dd>
+          <dt>ConstrainLong sampleRate</dt> <dd> </dd>
+          <dt>ConstrainLong sampleSize</dt><dd> </dd>
+          <dt>boolean echoCancelation</dt><dd> </dd>
+          <dt>ConstrainDOMString sourceId</dt> <dd> </dd>
+
+        </dl>
+      </section>
 
       <section>
         <h2>Isolated Media Streams</h2>
@@ -3075,7 +3076,7 @@
           href="#isolated-media-streams">isolated from the application</a>.</p>
         </dd>
       </dl>
-      
+
 
     </section>
 
@@ -3249,12 +3250,12 @@
     choose.</p>
 
     <pre xml:space="preserve" class="example highlight">
- var constraints = 
-  { 
-    width: {min: 640}, 
-    height: {min: 480}, 
+ var constraints =
+  {
+    width: {min: 640},
+    height: {min: 480},
     aspectRatio: {max: 1.5}
-  }; 
+  };
 </pre>
 
 
@@ -3267,13 +3268,13 @@
     the <code>successCallback</code>.</p>
 
     <pre xml:space="preserve" class="example highlight">
- var constraints = 
-  { 
-    require: ["width", "height"], 
-    width: {min: 640}, 
-    height: {min: 480}, 
+ var constraints =
+  {
+    require: ["width", "height"],
+    width: {min: 640},
+    height: {min: 480},
     aspectRatio: {max: 1.5}
-  }; 
+  };
 </pre>
 
     <p>This example illustrates the full control possible with the
@@ -3293,15 +3294,15 @@
     an aspectRatio no greater than 1.5 if possible."</p>
 
     <pre xml:space="preserve" class="example highlight">
- var constraints = 
-  { 
-    require: ["width", "height"], 
-    width: {min: 640}, 
-    height: {min: 480}, 
+ var constraints =
+  {
+    require: ["width", "height"],
+    width: {min: 640},
+    height: {min: 480},
     aspectRatio: {max: 1.5}
-    advanced: [{width: 1920, height: 1280}, 
-               {aspectRatio: 1.3333333333}] 
-  }; 
+    advanced: [{width: 1920, height: 1280},
+               {aspectRatio: 1.3333333333}]
+  };
 </pre>
 
     <p>The ordering of advanced ConstraintSets is significant. In the
@@ -3350,14 +3351,14 @@
     <section>
       <h2>Interface Definition</h2>
       <p>Due to the limitations of the interface definition language used
-      	in this  specification, it is not possible for other interfaces to 
-      	inherit or implement Constrainable.  Therefore the WwebIDL definitions
-      	given are only templates to be copied.  Each interface that wishes
-      	to make use of the functionality defined here will have to provide its
-      	own copy of the WebIDL for the functions and interfaces given here. However it 
-      	can refer to the semantics defined here, which will not change.  See
-      	<a href="#media-stream-track-interface-definition">MediaStreamTrack Interface Definition</a>
-      	for an example of this.</p>
+        in this  specification, it is not possible for other interfaces to
+        inherit or implement Constrainable.  Therefore the WwebIDL definitions
+        given are only templates to be copied.  Each interface that wishes
+        to make use of the functionality defined here will have to provide its
+        own copy of the WebIDL for the functions and interfaces given here. However it
+        can refer to the semantics defined here, which will not change.  See
+        <a href="#media-stream-track-interface-definition">MediaStreamTrack Interface Definition</a>
+        for an example of this.</p>
 
 
       <dl class="idl" title="[NoInterfaceObject] interface ConstrainablePattern">
@@ -3394,9 +3395,9 @@
 
 
         <dd>The <dfn>getConstraints</dfn> method returns the Constraints
-          	that were the argument to the
+                that were the argument to the
           last successful call of <code>applyConstraints()</code>, maintaining
-          the order in which they were specified.  
+          the order in which they were specified.
         Note that some of
           the optional ConstraintSets returned may not be currently satisfied.
           To check which ConstraintSets are currently in effect, the application
@@ -3447,8 +3448,8 @@
 
           <ul>
             <li>We refer to each element of a ConstraintSet (other than
-            	the special terms 'require' and 'advanced')
-            	as a 'constraint' since it is intended to constrain the
+                the special terms 'require' and 'advanced')
+                as a 'constraint' since it is intended to constrain the
 corresponding Capability of the Constrainable object to a value that is
 within the range or list of values it specifies.</li>
 <li>We refer to the "effective Capability" C of an object O as the possibly
@@ -3498,7 +3499,7 @@ for the properties of O.</li>
             whose names appear on the 'require' member of <var>newConstraints</var>.
             Let <var>unorderedConstraints</var> be all the other constraints
             in <var>newConstraints</var>.  Note that 'require' and 'advanced' are
-            not member of either of these sets, since they are not constraints, but 
+            not member of either of these sets, since they are not constraints, but
             represent meta-information about constraints.  In the following
             we treat <var>requiredConstraints</var> and <var>unorderedConstraints</var>
             as ConstraintSets.  </li>
@@ -3525,16 +3526,16 @@ for the properties of O.</li>
 
 
             <li>Let <var>successfulConstraints</var> be a list of ConstraintSets,
-            	initially containing only <var>requiredConstraints</var>.
-            	Iterate over the 'advanced' ConstraintSets in
+                initially containing only <var>requiredConstraints</var>.
+                Iterate over the 'advanced' ConstraintSets in
             <var>newConstraints</var> in the order in which they were
 
             specified. For each ConstraintSet, if it and
             <var>successfulConstraints</var> together can be satisfied by
-            <var>copy</var>, append it to the rear of <var>successfulConstraints</var>. 
+            <var>copy</var>, append it to the rear of <var>successfulConstraints</var>.
             Otherwise, skip it. </li>
-            
-            
+
+
 
 
             <li>In a single operation,
@@ -3552,9 +3553,9 @@ for the properties of O.</li>
             that were passed as an argument to this call. </li>
           </ol>
           <p>The UA <em title="may" class="rfc2119">may</em> choose new settings
-          	for the Capabilities of the object at any time.  When it does so
-          	it <em title="must" class="rfc2119">must</em> attempt to satisfy
-          	the current Constraints, in the manner described in the algorithm above.  </p>
+                for the Capabilities of the object at any time.  When it does so
+                it <em title="must" class="rfc2119">must</em> attempt to satisfy
+                the current Constraints, in the manner described in the algorithm above.  </p>
 
 
         <dt>attribute EventHandler onoverconstrained</dt>
@@ -3674,14 +3675,14 @@ for the properties of O.</li>
       <h2>The Property Registry</h2>
 
 
-      <p>There is a single <a href="#sec-iana">IANA registry</a> that 
-      	defines the constrainable 
-      	properties of all objects that implement the Constrainable patten. The
+      <p>There is a single <a href="#sec-iana">IANA registry</a> that
+        defines the constrainable
+        properties of all objects that implement the Constrainable patten. The
       registry entries <em title="must" class="rfc2119">must</em> contain the
       name of each property along with its set of legal values. The registry entries
       for MediaStreamTrack are defined <a href="#sec-constraints">below</a>. The
       syntax for the specification of the set of legal values depends on the
-      type of the values. 
+      type of the values.
        In addition to the standard atomic types (boolean, long, double,
       DOMString), legal values include lists of any of the atomic types, plus
       min-max ranges, as defined below.</p>
@@ -3703,7 +3704,7 @@ for the properties of O.</li>
 
 
 
-   
+
 
 
 
@@ -3734,12 +3735,12 @@ for the properties of O.</li>
 
           <dd>The minimum value of this property.</dd>
         </dl>
-        
+
      <dl class="idl" title="typedef (Long or ConstrainLongRange) ConstrainLong">
         </dl>
      <dl class="idl" title="typedef (Double or ConstrainDoubleRange) ConstrainDouble">
         </dl>
-        
+
       <dl class="idl" title="typedef (DOMtring or sequence&lt;DOMString&gt;) ConstrainDOMString">
         </dl>
 
@@ -3752,7 +3753,7 @@ for the properties of O.</li>
 
       <p><dfn>Capabilities</dfn> are dictionary containing one or more
       key-value pairs, where each key <em title="must" class=
-      "rfc2119">must</em> be a constrainable property defined in the 
+      "rfc2119">must</em> be a constrainable property defined in the
       registry, and each value <em title="should" class="rfc2119">must</em> be
       a subset of the set of values defined for that property in the registry.
       The exact syntax of the value expression depends on the type of the
@@ -3816,14 +3817,14 @@ for the properties of O.</li>
     <section id="constraints">
       <h3><dfn>Constraints and ConstraintSet</dfn>
       </h3>
-      <p>Due to the limitiations of WebIDl, interfaces implementing the 
-      	Constrainable Pattern cannnot simply subclass Constraints and
-      	ConstraintSet as they are defined here.  Instead they must provide their own
-      	definitions that follow this pattern.  See <a href="#media-track-constraints">
-      		MediaTrackConstraints</a> for an example of this.</p>
+      <p>Due to the limitiations of WebIDl, interfaces implementing the
+        Constrainable Pattern cannnot simply subclass Constraints and
+        ConstraintSet as they are defined here.  Instead they must provide their own
+        definitions that follow this pattern.  See <a href="#media-track-constraints">
+                MediaTrackConstraints</a> for an example of this.</p>
       <dl class="idl" title="typedef Dictionary ConstraintSet">
         </dl>
-    	
+
          <p>Each member of a ConstraintSet corresponds to a Capability
          and specifies a subset of its legal values.  Applying a
          ConstraintSet instructs that UA to restrict the setting of
@@ -3832,7 +3833,7 @@ for the properties of O.</li>
          basic Constraints set and in the advanced ConstraintSets
          list, and MAY occur at most once in each ConstraintSet in the
          advanced list.</p>
-       
+
       <dl class="idl" title="dictionary Constraints : ConstraintSet">
         <dt>
           sequence&lt;DOMString&gt; require
@@ -3869,8 +3870,8 @@ for the properties of O.</li>
         </dd>
       </dl>
 
-	
-      
+
+
     </section>
   </section>
 
@@ -4092,11 +4093,11 @@ for the properties of O.</li>
             </td>
 
             <td>
-              The type of the source of the <a>MediaStreamTrack. 
-              	Note that the setting of this property is uniquely determined by the source that is attached to the Track.  In particular, 
-              	getCapabilities() will return only a single value for sourceID/Type.   
-              	This property can therefore be used for initial media selection with getUserMedia().  However is not useful for subsequent media control with applyConstraints, since any attempt to 
-              	set a different value will result in an unsatisfiable ConstraintSet. </a>.
+              The type of the source of the <a>MediaStreamTrack.
+                Note that the setting of this property is uniquely determined by the source that is attached to the Track.  In particular,
+                getCapabilities() will return only a single value for sourceID/Type.
+                This property can therefore be used for initial media selection with getUserMedia().  However is not useful for subsequent media control with applyConstraints, since any attempt to
+                set a different value will result in an unsatisfiable ConstraintSet. </a>.
             </td>
           </tr>
 
@@ -4111,13 +4112,13 @@ for the properties of O.</li>
             identifier MUST be valid between sessions of this application, but
             MUST also be different for other applications. Some sort of GUID is
             recommended for the identifier.
-            Note that the setting of this property is uniquely determined by the source that is attached to the Track.  In particular, 
-              	getCapabilities() will return only a single value for sourceID/Type.   
-              	This property can therefore be used for initial media selection with getUserMedia().  However is not useful for subsequent media control with applyConstraints, since any attempt to 
-              	set a different value will result in an unsatisfiable ConstraintSet. </td>
+            Note that the setting of this property is uniquely determined by the source that is attached to the Track.  In particular,
+                getCapabilities() will return only a single value for sourceID/Type.
+                This property can therefore be used for initial media selection with getUserMedia().  However is not useful for subsequent media control with applyConstraints, since any attempt to
+                set a different value will result in an unsatisfiable ConstraintSet. </td>
           </tr>
 
-          
+
        </tbody>
       </table>
 
@@ -4265,7 +4266,7 @@ for the properties of O.</li>
 
 
         <tbody>
-          
+
           <tr id="def-constraint-volume">
             <td>volume</td>
 
@@ -4298,12 +4299,12 @@ for the properties of O.</li>
 
             <td>The linear sample size in bits. This constraint can only be
               satisfied for audio devices that produce linear samples. </td>
-          
+
           </tr>
 
           <tr id="def-constraint-echoCancelation">
             <td> echoCancelation </td>
-            
+
             <td>
               <code>boolean</code>
             </td>
@@ -4317,7 +4318,7 @@ for the properties of O.</li>
               control this behavior. </td>
 
             </tr>
-          
+
         </tbody>
       </table>
 
@@ -4329,7 +4330,7 @@ for the properties of O.</li>
 
 
       <dl>
-       
+
       </dl>
     </section>
   </section>
@@ -4353,11 +4354,11 @@ for the properties of O.</li>
 
 
     <h2>Changes since March 21, 2014</h2>
-    
+
 
     <ol>
-    	<li>New webIDL for Constrainable and Constraints.</li>
-    	<li>Bug 24931: changed MediaError to MediaStreamError.</li>
+        <li>New webIDL for Constrainable and Constraints.</li>
+        <li>Bug 24931: changed MediaError to MediaStreamError.</li>
       <li>Bug 23817: [Nit] Redundant TOC headers 8.1 & 9.1</li>
 
       <li>Bug 25230: readyState attribute must be inherited while cloning a

--- a/webrtc.html
+++ b/webrtc.html
@@ -1219,7 +1219,7 @@
               </li>
 
               <li>
-                <p>If the "peerIdentity" constraint is applied to the
+                <p>If the "peerIdentity" option is applied to the
                 <code><a>RTCPeerConnection</a></code>, this establishes a <dfn
                 id="target-peer-identity">target peer identity</dfn>.
                 Alternatively, if the <code><a>RTCPeerConnection</a></code> has
@@ -1233,11 +1233,9 @@
                 identity</a>, then <code>setRemoteDescription</code> fails
                 unless it contains an identity assertion that matches the <a
                 href="#target-peer-identity">target peer identity</a>.  The
-                <code>RTCPeerConnection</code> MAY be closed if the validated
-                peer identity does not match the <a
-                href="#target-peer-identity">target peer identity</a>.  [[TODO:
-                determine if it is possible at this point to back out the
-                change.  Seems unlikely.]]</p>
+                <code><a>RTCPeerConnection</a></code> MAY be closed if the
+                validated peer identity does not match the <a
+                href="#target-peer-identity">target peer identity</a>.</p>
               </li>
            </ul>
           </dd>
@@ -1664,13 +1662,9 @@
                 href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#cors-cross-origin">CORS
                 cross-origin</a>.  These streams can be added to the <a
                 href="#local-streams-set">local streams set</a> but content MUST
-                NOT be transmitted, with one exception.</p>
-
-                <p>A stream marked with the <var>peerIdentity</var> option can
-                be transmitted if the RTCPeerConnection has successfully <a
-                href="sec.identity-verify-assertion">validated the identity</a>
-                of the peer to have the same identity as the value of the
-                <var>peerIdentity</var> option on the stream.</p>
+                NOT be transmitted, though streams marked with
+                <var>peerIdentity</var> can be transmitted if they meet the
+                requirements for sending (see <a href="#isolated-pc"></a>) .</p>
 
                 <p>All other streams that are not accessible to the application
                 MUST NOT be sent to the peer, with silence (audio), black frames
@@ -4928,19 +4922,19 @@ function processStats() {
 
       <p>A MediaStream acquired using <code>getUserMedia()</code> is, by
       default, accessible to an application.  This means that the application is
-      able to access the contents of the tracks, modify their content, and send
-      that media to any peer it chooses.</p>
+      able to access the contents of tracks, modify their content, and send that
+      media to any peer it chooses.</p>
 
       <p>WebRTC supports calling scenarios where media is sent to a specifically
       identified peer, without the contents of media streams being accessible to
-      applications.  This is enabled by use of
-      the <code><dfn>peerIdentity</dfn></code> parameter
-      to <code>getUserMedia()</code>.</p>
+      applications.  This is enabled by use of the
+      <code><dfn>peerIdentity</dfn></code> parameter to
+      <code>getUserMedia()</code>.</p>
 
-      <p>An application willingly relinquishes access to media by including
-      a <code>peerIdentity</code> parameter in
-      the <code>MediaStreamConstraints</code>.  This attribute is set to
-      a <code>DOMString</code> containing the identity of a specific peer.</p>
+      <p>An application willingly relinquishes access to media by including a
+      <code>peerIdentity</code> parameter in the
+      <code>MediaStreamConstraints</code>.  This attribute is set to a
+      <code>DOMString</code> containing the identity of a specific peer.</p>
 
       <p>The <code><dfn>MediaStreamConstraints</dfn></code> dictionary is
       expanded to include the <code>peerIdentity</code> parameter.</p>
@@ -4949,7 +4943,7 @@ function processStats() {
         <dt>DOMString peerIdentity</dt>
         <dd>
           <p>If set, <code>peerIdentity</code> isolates media from the
-          application.</p>
+          application.  Media can only be sent to the identified peer.</p>
         </dd>
       </dl>
 
@@ -4958,10 +4952,11 @@ function processStats() {
       parameter, so that they can be informed that the consent is more narrowly
       restricted.</p>
 
-      <p>When the <code><dfn>peerIdentity</dfn></code> option is supplied
-      to <code>getUserMedia()</code>, the resulting <code>MediaStream</code> is
-      isolated so that its content is not accessible to any application. An
-      isolated <code>MediaStream</code> can be used for two purposes:</p>
+      <p>When the <code><dfn>peerIdentity</dfn></code> option is supplied to
+      <code>getUserMedia()</code>, all of the <code>MediaStreamTrack</code>s in
+      the resulting <code>MediaStream</code> are isolated so that content is not
+      accessible to any application.  Isolated <code>MediaStreamTrack</code>s
+      can be used for two purposes:</p>
 
       <ul>
         <li>
@@ -4976,17 +4971,18 @@ function processStats() {
         </li>
 
         <li>
-          <p>Used as the argument
-          to <a href="#widl-RTCPeerConnection-addStream-void-MediaStream-stream">addStream()</a>
-          on an <code><a>RTCPeerConnection</a></code> instance.</p>
+          <p>Used as the argument to <a
+          href="#widl-RTCPeerConnection-addStream-void-MediaStream-stream">addStream()</a>
+          on an <code><a>RTCPeerConnection</a></code> instance, subject to the
+          restrictions in <a href="#isolated-pc"></a>.</p>
         </li>
       </ul>
 
-      <p>A <code>MediaStreamTrack</code> that is added to
-      another <code>MediaStream</code> remains isolated.  Tracks that are
-      isolated can be added to other <code>MediaStream</code>s, but this causes
-      the resulting MediaStream to have a combination of isolation restrictions.
-      A <code>MediaStream</code> containing <code>MediaStreamTrack</code>
+     <p>A <code>MediaStreamTrack</code> that is added to another
+      <code>MediaStream</code> remains isolated.  Tracks that are isolated can
+      be added to other <code>MediaStream</code>s, but this causes the resulting
+      MediaStream to have a combination of isolation restrictions.  A
+      <code>MediaStream</code> containing <code>MediaStreamTrack</code>
       instances with mixed isolation properties can be displayed, but cannot be
       sent using <code><a>RTCPeerConnection</a></code>.</p>
 
@@ -4998,6 +4994,67 @@ function processStats() {
            through <a href="https://www.w3.org/TR/streamproc/#media-element-extensions">captureStreamUntilEnded
            or captureStream</a>, MUST also retain any isolation protections.
         -->
+
+      <section id="isolated-pc">
+        <h4>Isolated Streams and RTCPeerConnection</h4>
+
+        <p>A <code>MediaStreamTrack</code> with a <var>peerIdentity</var> option
+        set can be added to any <code><a>RTCPeerConnection</a></code>.  However,
+        the content of an isolated track MUST NOT be transmitted unless all of
+        the following constraints are met:</p>
+
+        <ul>
+          <li>
+            <p>A <code>MediaStreamTrack</code> from a stream acquired using the
+            <var>peerIdentity</var> option can be transmitted if the
+            <code><a>RTCPeerConnection</a></code> has successfully <a
+            href="sec.identity-verify-assertion">validated the identity</a> of
+            the peer AND that identity is the same identity that was used in the
+            <var>peerIdentity</var> option associated with the track.  That is,
+            the <code>name</code> attribute of the <code>peerIdentity</code>
+            attribute of the <code><a>RTCPeerConnection</a></code> instance MUST
+            match the value of the <code>peerIdentity</code> option passed to
+            <code>getUserMedia()</code>.</p>
+
+            <p>Rules for matching identity are described in
+            [[!RTCWEB-SECURITY-ARCH]].</p>
+          </li>
+
+          <li>
+            <p>The peer has indicated that it will respect the isolation
+            properties of streams.  That is, a DTLS connection with a promise to
+            respect stream confidentiality, as defined in [[!WEBRTC-ALPN]] has
+            been established.</p>
+          </li>
+        </ul>
+
+        <p>Failing to meet these conditions means that no media can be sent for
+        the affected <code>MediaStreamTrack</code>.  Video MUST be replaced by
+        black frames, audio MUST be replaced by silence, and equivalently
+        information-free content MUST be provided for other media types.</p>
+
+        <p>Remotely sourced <code>MediaStreamTrack</code>s MUST be isolated if
+        they are received over a DTLS connection that has been negotiated with
+        track isolation.  This protects isolated media from the application in
+        the receiving browser.  These tracks MUST only be displayed to a user
+        using the appropriate media element (e.g., &gt;video> or
+        &gt;audio>).</p>
+
+        <p>A single isolated <code>MediaStreamTrack</code> causes all tracks
+        sent using the same <code><a>RTCPeerConnection</a></code> to be isolated
+        at the receiving peer.  All DTLS connections created for a
+        <code><a>RTCPeerConnection</a></code> with isolated local streams MUST
+        be negotiated so that media remains isolated at the remote peer.  This
+        causes non-isolated media to become isolated at the receiving peer if
+        any isolated tracks are added to the
+        <code><a>RTCPeerConnection</a></code>.</p>
+
+        <p>If a stream becomes isolated after initially being accessible, or an
+        isolated stream is added to an active session, then media for that
+        stream is replaced by information-free content (e.g., black frames or
+        silence).</p>
+
+      </section>
     </section>
 
   </section>

--- a/webrtc.html
+++ b/webrtc.html
@@ -4978,21 +4978,23 @@ function processStats() {
         </li>
       </ul>
 
-     <p>A <code>MediaStreamTrack</code> that is added to another
-      <code>MediaStream</code> remains isolated.  Tracks that are isolated can
-      be added to other <code>MediaStream</code>s, but this causes the resulting
-      MediaStream to have a combination of isolation restrictions.  A
-      <code>MediaStream</code> containing <code>MediaStreamTrack</code>
-      instances with mixed isolation properties can be displayed, but cannot be
-      sent using <code><a>RTCPeerConnection</a></code>.</p>
-
       <p>Any <code>peerIdentity</code> property MUST be retained on cloned
       copies of <code>MediaStreamTrack</code>s.</p>
 
+      <p>The isolation property of each indivdual track determines what
+      restrictions apply.  A <code>MediaStreamTrack</code> that is added to
+      another <code>MediaStream</code> remains isolated.  Thus, a
+      <code>MediaStream</code> can have a combination of isolation properties on
+      the set of tracks it contains.</p>
+
       <!-- Any stream or track that might be derived from an isolated stream,
-           such as
-           through <a href="https://www.w3.org/TR/streamproc/#media-element-extensions">captureStreamUntilEnded
+           such as through <a
+           href="https://www.w3.org/TR/streamproc/#media-element-extensions">captureStreamUntilEnded
            or captureStream</a>, MUST also retain any isolation protections.
+           Where playback is switched between tracks with different isolation
+           properties, <code>captureStream</code> and
+           <code>captureStreamUntilEnded</code> produce tracks with dynamically
+           changing isolation properties.
         -->
 
       <section id="isolated-pc">

--- a/webrtc.html
+++ b/webrtc.html
@@ -4076,7 +4076,6 @@ function processStats() {
   <section>
     <h2 id="sec.identity-proxy">Identity</h2>
 
-
     <section>
       <h3>Identity Provider Interaction</h3>
 
@@ -4923,6 +4922,84 @@ function processStats() {
         </dd>
       </dl>
     </section>
+
+    <section>
+      <h3>Isolated Media Streams</h3>
+
+      <p>A MediaStream acquired using <code>getUserMedia()</code> is, by
+      default, accessible to an application.  This means that the application is
+      able to access the contents of the tracks, modify their content, and send
+      that media to any peer it chooses.</p>
+
+      <p>WebRTC supports calling scenarios where media is sent to a specifically
+      identified peer, without the contents of media streams being accessible to
+      applications.  This is enabled by use of
+      the <code><dfn>peerIdentity</dfn></code> parameter
+      to <code>getUserMedia()</code>.</p>
+
+      <p>An application willingly relinquishes access to media by including
+      a <code>peerIdentity</code> parameter in
+      the <code>MediaStreamConstraints</code>.  This attribute is set to
+      a <code>DOMString</code> containing the identity of a specific peer.</p>
+
+      <p>The <code><dfn>MediaStreamConstraints</dfn></code> dictionary is
+      expanded to include the <code>peerIdentity</code> parameter.</p>
+
+      <dl class="idl" title="dictionary MediaStreamConstraints">
+        <dt>DOMString peerIdentity</dt>
+        <dd>
+          <p>If set, <code>peerIdentity</code> isolates media from the
+          application.</p>
+        </dd>
+      </dl>
+
+      <p>A user that is prompted to provide consent for access to a camera or
+      microphone can be shown the value of the <code>peerIdentity</code>
+      parameter, so that they can be informed that the consent is more narrowly
+      restricted.</p>
+
+      <p>When the <code><dfn>peerIdentity</dfn></code> option is supplied
+      to <code>getUserMedia()</code>, the resulting <code>MediaStream</code> is
+      isolated so that its content is not accessible to any application. An
+      isolated <code>MediaStream</code> can be used for two purposes:</p>
+
+      <ul>
+        <li>
+          <p>Displayed in an appropriate media tag (e.g., a video or audio
+          element). The browser MUST ensure that content is inaccessible to the
+          application by ensuring that the resulting content is given the same
+          protections as content that
+          is <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#cors-cross-origin">CORS
+          cross-origin</a>, as described in the
+          relevant <a href="http://www.w3.org/html/wg/drafts/html/master/embedded-content-0.html#security-and-privacy-considerations">Security
+          and privacy considerations section </a> of [[HTML5]].</p>
+        </li>
+
+        <li>
+          <p>Used as the argument
+          to <a href="#widl-RTCPeerConnection-addStream-void-MediaStream-stream">addStream()</a>
+          on an <code><a>RTCPeerConnection</a></code> instance.</p>
+        </li>
+      </ul>
+
+      <p>A <code>MediaStreamTrack</code> that is added to
+      another <code>MediaStream</code> remains isolated.  Tracks that are
+      isolated can be added to other <code>MediaStream</code>s, but this causes
+      the resulting MediaStream to have a combination of isolation restrictions.
+      A <code>MediaStream</code> containing <code>MediaStreamTrack</code>
+      instances with mixed isolation properties can be displayed, but cannot be
+      sent using <code><a>RTCPeerConnection</a></code>.</p>
+
+      <p>Any <code>peerIdentity</code> property MUST be retained on cloned
+      copies of <code>MediaStreamTrack</code>s.</p>
+
+      <!-- Any stream or track that might be derived from an isolated stream,
+           such as
+           through <a href="https://www.w3.org/TR/streamproc/#media-element-extensions">captureStreamUntilEnded
+           or captureStream</a>, MUST also retain any isolation protections.
+        -->
+    </section>
+
   </section>
 
 
@@ -5631,25 +5708,25 @@ sender.insertDTMF("123");
 
     <ol>
       <li>  Changes to identity-related text: </li>
-      
+
       <ul>
-     
+
         <li> Removed noaccess constraint </li>
-        
+
         <li> Add the ability to peerIdentity constrain RTCPeerConnection, which
         limits communication to a single peer </li>
-   
+
         <li> Change the way that the browser communicates with IdP to a message
         channel (http://www.w3.org/TR/webmessaging/#message-channels) </li>
-        
+
         <li> Improved error feedback from IdP interactions (added new events
         with more detailed context) </li>
-        
+
         <li> Changed the way that an IdP is able to request user login
         (LOGINNEEDED message) </li>
-        
+
       </ul>
-            
+
       <li>Bug 25155: maxRetransmitTime is not the name of the SCTP concept it
       points to.</li>
     </ol>


### PR DESCRIPTION
So, as requested, I've moved the whole stream isolation section from gUM to WebRTC.  In addition to that, I've added more text about isolation, in anticipation of an outcome to some of the discussions in D.C.   You might want to hold onto this until we've had that discussion.

I also fixed up [bug 25774](https://www.w3.org/Bugs/Public/show_bug.cgi?id=25774) while at it.

gUM was a mess whitespace-wise, so I cleaned that up first. 
