### PR TITLE
Removing invalid note about multiple a=identity attributes

### DIFF
--- a/webrtc.html
+++ b/webrtc.html
@@ -4162,12 +4162,6 @@ function logError(error) {
         running to completion can be treated as equivalent to an error from
         the IdP.</p>
 
-        <p>It is possible that different values for the "a=identity" attribute
-        is provided at a media level in SDP. A browser MAY either choose to
-        treat this as an error or ignore the attribute. If multiple different
-        assertions are validated, then they MUST produce identical identity
-        values.</p>
-
         <p>The format and contents of the messages that are exchanged are
         described in detail in [[!RTCWEB-SECURITY-ARCH]].</p>
       </section>


### PR DESCRIPTION
Bernard found this.  Since a=identity is a session-level attribute now, this is no longer true, or necessary.
